### PR TITLE
Fix default type comment

### DIFF
--- a/index.php
+++ b/index.php
@@ -25,8 +25,8 @@
           if (!empty($meta['type'])) {
               $type = $meta['type'];
           } else {
-              // Fallback to the file's last modification time
-              $type = "single";
+                // Default to single type when not specified.
+                $type = "single";
           }
 
           // Get content & summary


### PR DESCRIPTION
## Summary
- clarify comment for `$type` default in `index.php`

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_6842b22cf1ec8321a998506fba05052a