### PR TITLE
Fix RSS fetchContent call

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -29,7 +29,7 @@ rsort($files);
 foreach ($files as $postFile) {
     $link_id = pathinfo($postFile, PATHINFO_FILENAME);
     $frontmatter = new FrontMatter($postFile);
-    $postContent = $frontmatter->fetchContent($postFile);
+    $postContent = $frontmatter->fetchContent();
     $Parsedown = new Parsedown();
     $newItem = $TestFeed->createNewItem();
     $meta = $frontmatter->fetchMeta();


### PR DESCRIPTION
## Summary
- ensure `rss.php` fetches content without arguments

## Testing
- `php -l rss.php`
- `find . -name '*.php' -print0 | xargs -0 -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_6842b21f10e08321aa76885283d305a9