### PR TITLE
Add RSS feed PHPUnit tests

### DIFF
--- a/tests/RssTest.php
+++ b/tests/RssTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class RssTest extends TestCase
+{
+    public function testFeedContainsPosts()
+    {
+        ob_start();
+        include 'rss.php';
+        $xml = ob_get_clean();
+
+        $feed = new SimpleXMLElement($xml);
+        $items = $feed->channel->item;
+
+        $expected = [
+            [
+                'title' => 'One World',
+                'link'  => 'https://nithou.net/sandbox/single.php?id=2023-09-01',
+            ],
+            [
+                'title' => 'We chose to go to the moon',
+                'link'  => 'https://nithou.net/sandbox/single.php?id=2023-08-01',
+            ],
+        ];
+
+        $this->assertCount(count($expected), $items);
+        foreach ($expected as $index => $exp) {
+            $this->assertEquals($exp['title'], (string)$items[$index]->title);
+            $this->assertEquals($exp['link'], (string)$items[$index]->link);
+        }
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+// Ensure relative paths work from repository root
+chdir(__DIR__ . '/..');
+// Buffer output so headers can be set in scripts under test
+ob_start();

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="TinyBlogEngine">
+            <directory suffix="Test.php">.</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Summary
- add PHPUnit configuration and bootstrap in `tests/`
- create RSS feed integration test verifying posts are included in RSS output

## Testing
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6842b33848d88321977ce4a3735bfbfc